### PR TITLE
not treating an explicit undefined as a child

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function element (type, attributes, children) {
 
   // Account for JSX putting the children as multiple arguments.
   // This is essentially just the ES6 rest param
-  if (arguments.length > 2 && Array.isArray(arguments[2]) === false) {
+  if (arguments.length > 2 && children && Array.isArray(arguments[2]) === false) {
     children = slice(arguments, 2)
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -74,6 +74,22 @@ it('should allow skipping attributes and using a single child', function () {
   assert(node.children[0] === 'foo')
 })
 
+it('should not treat undefined as a child', function () {
+  var node
+
+  node = element('div')
+  assert.strictEqual(node.children.length, 0)
+
+  node = element('div', undefined)
+  assert.strictEqual(node.children.length, 0)
+
+  node = element('div', {})
+  assert.strictEqual(node.children.length, 0)
+
+  node = element('div', {}, undefined)
+  assert.strictEqual(node.children.length, 0)
+})
+
 it('render nodes that work with JSX', function(){
   assert.deepEqual(
     <div class="one" id="foo">Hello World</div>,


### PR DESCRIPTION
If `undefined` is passed explicitly for `children`, this causes it to treat that as a child, resulting in `[ undefined ]`. This patches that hole, which should hopefully fix `magic-virtual-element` upstream.

/cc @anthonyshort 
