### PR TITLE
Allowing for sparse lists of children

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,24 +43,18 @@ function element (type, attributes, children) {
   // Skipped adding attributes and we're passing
   // in children instead.
   if (arguments.length === 2 && (typeof attributes === 'string' || Array.isArray(attributes))) {
-    children = attributes
+    children = [ attributes ]
     attributes = {}
   }
 
   // Account for JSX putting the children as multiple arguments.
   // This is essentially just the ES6 rest param
-  if (arguments.length > 2 && children && Array.isArray(arguments[2]) === false) {
+  if (arguments.length > 2 && typeof children !== 'undefined') {
     children = slice(arguments, 2)
   }
 
   children = children || []
   attributes = attributes || {}
-
-  // passing in a single child, you can skip
-  // using the array
-  if (!Array.isArray(children)) {
-    children = [children]
-  }
 
   // Flatten nested child arrays. This is how JSX compiles some nodes.
   children = flatten(children, 2)

--- a/test/index.js
+++ b/test/index.js
@@ -74,6 +74,27 @@ it('should allow skipping attributes and using a single child', function () {
   assert(node.children[0] === 'foo')
 })
 
+it('should allow sparse lists of children', function () {
+  var node
+
+  node = element('div', {}, null, 'a', 'b', null, 'c')
+  assert(node.children.length, 5)
+
+  // even w/o attrs
+  node = element('div', 'a', null, 'c')
+  assert(node.children.length, 3)
+})
+
+it('should allow nested arrays as children', function () {
+  var node
+
+  node = element('div', {}, null, [ 'a', 'b' ], 'c')
+  assert(node.children.length, 3)
+
+  node = element('div', null, [ 'a', 'b' ], 'c')
+  assert(node.children.length, 3)
+})
+
 it('should not treat undefined as a child', function () {
   var node
 


### PR DESCRIPTION
Currently, if the first child is `null`, all the children are ignored. This cleans up the code and leverages `array-flatten` more completely to reduce this complexity. (with tests!)

/cc @anthonyshort 
