### PR TITLE
Handling undefined children in sparse lists better

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function element (type, attributes, children) {
 
   // Account for JSX putting the children as multiple arguments.
   // This is essentially just the ES6 rest param
-  if (arguments.length > 2 && typeof children !== 'undefined') {
+  if (arguments.length > 2) {
     children = slice(arguments, 2)
   }
 
@@ -58,6 +58,9 @@ function element (type, attributes, children) {
 
   // Flatten nested child arrays. This is how JSX compiles some nodes.
   children = flatten(children, 2)
+
+  // Filter out any `undefined` elements
+  children = children.filter(function (i) { return typeof i !== 'undefined' })
 
   // if you pass in a function, it's a `Component` constructor.
   // otherwise it's an element.

--- a/test/index.js
+++ b/test/index.js
@@ -111,6 +111,13 @@ it('should not treat undefined as a child', function () {
   assert.strictEqual(node.children.length, 0)
 })
 
+it('should not ignore subsequent children when the first is undefined', function () {
+  var node
+
+  node = element('div', {}, undefined, 'a')
+  assert.strictEqual(node.children.length, 1)
+})
+
 it('render nodes that work with JSX', function(){
   assert.deepEqual(
     <div class="one" id="foo">Hello World</div>,


### PR DESCRIPTION
Currently, `deku@master` is failing on CI because children are being excluded altogether if the first one is `undefined`. This PR basically makes it so that any time the number of arguments > 2, it will take arguments 2+ and filter out any `undefined` values.

Part of me wonders if we should just treat `undefined` the same as `null` and `false`. If we go that route, this PR will need to be modified slightly.
